### PR TITLE
useframev2

### DIFF
--- a/src/OneWireAnalyzer.cpp
+++ b/src/OneWireAnalyzer.cpp
@@ -11,6 +11,7 @@
 OneWireAnalyzer::OneWireAnalyzer() : mSettings( new OneWireAnalyzerSettings() ), Analyzer2(), mSimulationInitilized( false )
 {
     SetAnalyzerSettings( mSettings.get() );
+    UseFrameV2();
 }
 
 OneWireAnalyzer::~OneWireAnalyzer()


### PR DESCRIPTION
This won't build until the new UseFrameV2(); Function has become an official part of the SDK. In the meantime, do not use `UseFrameV2();`, as it will fail to build.